### PR TITLE
Added fix for crash observed on listener update while draining old listener's place-holder filter-chain

### DIFF
--- a/source/server/filter_chain_manager_impl.h
+++ b/source/server/filter_chain_manager_impl.h
@@ -139,7 +139,12 @@ public:
     rebuilt_filter_chain_ = nullptr;
   }
 
-  void startDraining() override { factory_context_->startDraining(); }
+  void startDraining() override {
+    if (is_placeholder_ && !has_rebuilt_filter_chain_ && factory_context_ == nullptr) {
+      return;
+    }
+    factory_context_->startDraining();
+  }
 
   void setFilterChainFactoryContext(
       Configuration::FilterChainFactoryContextPtr filter_chain_factory_context) {


### PR DESCRIPTION
When we push a listener configuration containing an on-demand filter chain, a placeholder is created for that. Thus, no FilterChainFactoryContext is created (factory_context_ == nullptr). This factory_context_ is used by filter chain draining logic to trigger the filter chain draining process.

If we again push a new listener config with changes in the on-demand filter chain, this will drain the previous placeholder. It will use factory_context_ to trigger the draining process. But since factory_context_ is null, calling startDraining() function using factory_context_ caused a segfault (crash).

These changes fix that crash.